### PR TITLE
Webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,7 @@ node_modules
 *.js
 *.js.map
 
+!webpack.config.js
+
 # types
 typings

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ While writing this app, I found the following resources very helpful:
 * [Dependency Injection in Angular 1 and Angular 2](http://victorsavkin.com/post/126514197956/dependency-injection-in-angular-1-and-angular-2)
 
 Built with:
-* [esri-system-js](npmjs.com/esri-system-js)
 * [ArcGIS API for JavaScript]
 * [Angular 2]
 * [TypeScript]

--- a/app/map.service.ts
+++ b/app/map.service.ts
@@ -1,11 +1,16 @@
 import { Injectable } from '@angular/core';
-import { arcgisUtils, esriBasemaps, Legend, Search } from 'esri';
+import arcgisUtils = require('esri/arcgis/utils');
+import esriBasemaps = require('esri/basemaps');
+import Legend = require('esri/dijit/Legend');
+import Search = require('esri/dijit/Search');
+import {LegendOptions} from "esri";
+
 
 @Injectable()
 export class MapService {
   _basemaps: any[];
 
-  // load a web map and return response
+  // load a web map and return respons
   createMap(itemIdOrInfo: any, domNodeOrId: any, options: Object) {
     return arcgisUtils.createMap(itemIdOrInfo, domNodeOrId, options).then(response => {
       // append layer infos and basemap name to response before returning
@@ -21,7 +26,7 @@ export class MapService {
   };
 
   // create a legend dijit at the dom node
-  createLegend(options: Object, domNodeOrId: any) {
+  createLegend(options: LegendOptions, domNodeOrId: any) {
     return new Legend(options, domNodeOrId);
   };
 

--- a/index.html
+++ b/index.html
@@ -9,44 +9,18 @@
     <link rel="stylesheet" href="//js.arcgis.com/3.16/esri/themes/calcite/dijit/calcite.css">
     <link rel="stylesheet" href="//js.arcgis.com/3.16/esri/themes/calcite/esri/esri.css">
     <link rel="stylesheet" href="app/styles/main.css">
-
-    <!-- 1. Load libraries -->
-    <!-- Polyfill(s) for older browsers -->
-    <script src="node_modules/core-js/client/shim.min.js"></script>
-    <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
-    <script src="node_modules/systemjs/dist/system.src.js"></script>
-    <script src="systemjs.config.js"></script>
     
-    <!-- 2. Configure and load Esri libraries -->
+    <!-- 1. Configure and load ESRI libraries -->
     <script>
       window.dojoConfig = {
         async: true
       };
     </script>
     <script src="https://js.arcgis.com/3.16/"></script>
-    <script src="node_modules/esri-system-js/dist/esriSystem.js"></script>
 
-    <!-- 3. Configure SystemJS -->
-    <script src="systemjs.config.js"></script>
+    <!-- Load webpack bundles-->
     <script>
-      // load esri modules needed by this application
-      // into a System.js module called esri
-        esriSystem.register([
-          'esri/arcgis/utils',
-          'esri/basemaps',
-          'esri/dijit/Legend',
-          'esri/dijit/Search'
-        ], function () {
-          // then bootstrap application
-          System.import('app')
-            .catch(function(err){ console.error(err); });
-        }, {
-          moduleNameOverrides: {
-            'esri/arcgis/utils': 'arcgisUtils',
-            'esri/basemaps': 'esriBasemaps'
-          }
-        });
+      require(["/dist/vendor.bundle.js", "/dist/main.bundle.js"], function (vendor, main) {});
     </script>
   </head>
 
@@ -55,5 +29,6 @@
     <div class="container-fluid">
       <my-app>Loading...</my-app>
     </div>
+
   </body>  
 </html>

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   },
   "scripts": {
     "test": "tsc",
-    "tsc:w": "tsc -w",
+    "webpack:w": "webpack --watch",
     "lite": "lite-server",
-    "start": "concurrently \"npm run tsc:w\" \"npm run lite\" ",
+    "start": "concurrently \"npm run webpack:w\" \"npm run lite\" ",
     "postinstall": "typings install",
-    "tsc": "tsc",
+    "webpack": "webpack",
     "typings": "typings"
   },
   "keywords": [
@@ -31,8 +31,6 @@
     "@angular/router": "2.0.0-rc.1",
     "@angular/router-deprecated": "2.0.0-rc.1",
     "@angular/upgrade": "2.0.0-rc.1",
-    "esri-system-js": "0.0.3",
-    "systemjs": "0.19.27",
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.6",
@@ -41,7 +39,9 @@
   "devDependencies": {
     "concurrently": "^2.0.0",
     "lite-server": "^2.2.0",
+    "ts-loader": "^0.8.2",
     "typescript": "^1.8.10",
-    "typings": "^1.0.4"
+    "typings": "^1.0.4",
+    "webpack": "^1.13.1"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,7 @@
 {
   "globalDependencies": {
-    "core-js": "registry:dt/core-js#0.0.0+20160524134847"
+    "core-js": "registry:dt/core-js#0.0.0+20160524134847",
+    "arcgis-js-api": "github:Esri/jsapi-resources/3.x/typescript/arcgis-js-api.d.ts",
+    "dojo": "registry:dt/dojo#1.9.0+20160521151917"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,66 @@
+var webpack = require("webpack");
+
+module.exports = {
+    entry: {
+        main: [
+            './app/boot.ts' // entry point for your application code
+        ],
+        vendor: [
+            // put your third party libs here
+            "core-js",
+            "reflect-metadata", // order is important here
+            "rxjs",
+            "zone.js",
+            '@angular/core',
+            "@angular/compiler",
+            "@angular/core",
+            "@angular/http",
+            "@angular/platform-browser",
+            "@angular/platform-browser-dynamic",
+            "@angular/router",
+            "@angular/router-deprecated",
+            "@angular/upgrade"
+        ]
+    },
+    output: {
+        filename: './dist/[name].bundle.js',
+        publicPath: './',
+        libraryTarget: "amd"
+    },
+    resolve: {
+        extensions: ['', '.webpack.js', '.web.js', '.ts', '.tsx', '.js']
+    },
+    module: {
+        loaders: [
+            {
+                test: /\.tsx?$/,
+                loader: 'ts-loader',
+                exclude: ''
+            },
+            // css
+            {
+                test: /\.css$/,
+                loader: "style-loader!css-loader"
+            }
+        ]
+    },
+    plugins: [
+        new webpack.optimize.CommonsChunkPlugin({
+            name: 'vendor',
+            minChunks: Infinity
+        })
+    ],
+    externals: [
+        function(context, request, callback) {
+            if (/^dojo/.test(request) ||
+                /^dojox/.test(request) ||
+                /^dijit/.test(request) ||
+                /^esri/.test(request)
+            ) {
+                return callback(null, "amd " + request);
+            }
+            callback();
+        }
+    ],
+    devtool: 'source-map'
+};


### PR DESCRIPTION
Working sample with webpack.  I'm not sure how to get the typings to work properly with esri-system-js--it seems like pulling in the JSAPI typings causes some conflict, since they both get aliased to `esri`; using just the JSAPI typings, you have to use the older import syntax.

I'm an Angular n00b, so maybe you can get both working together, just thought this might be a useful jumping off point.  
- Removes systemjs dependencies
- Brings in typings for dojo and jsapi
- Adds webpack and config
- Edits index.html to require bundles
