### PR TITLE
Fixed deprecated # in ngFor. Replaced # with let.

### DIFF
--- a/app/tabs.component.ts
+++ b/app/tabs.component.ts
@@ -6,7 +6,7 @@ import { TabComponent } from './tab.component';
     template:
     `
     <ul class="nav nav-tabs" style="float: right; width:100%; margin-bottom:20px;">
-      <li *ngFor="#tab of tabs" (click)="selectTab(tab)" [class.active]="tab.active">
+      <li *ngFor="let tab of tabs" (click)="selectTab(tab)" [class.active]="tab.active">
         <a href="#">
             {{ tab.title }}
         </a>


### PR DESCRIPTION
Fixed error in console: "#" inside of expressions is deprecated. Use "let" instead!

Replaced # with let in ngFor.
